### PR TITLE
fix(signup-endpoint): Remove profile data from signup endpoint request body

### DIFF
--- a/backend/src/api/routes/authentication.py
+++ b/backend/src/api/routes/authentication.py
@@ -7,6 +7,7 @@ from src.models.schema.account import (
     AccountInSignout,
     AccountInSignoutResponse,
     AccountInSignup,
+    AccountInSignupResponse,
     AccountWithToken,
 )
 from src.repository.crud.account import AccountCRUDRepository
@@ -40,10 +41,11 @@ async def account_registration_endpoint(
     new_account = await account_crud.create_account(account_signup=account_signup)
     new_profile = await profile_crud.create_profile(parent_account=new_account)
     jwt_token = jwt_manager.generate_jwt(account=new_account)
-    return AccountInResponse(
+    return AccountInSignupResponse(
         authorized_account=AccountWithToken(
             token=jwt_token, hashed_password=new_account.hashed_password, **new_account.__dict__
-        )
+        ),
+        is_profile_created=True if new_profile else False,
     )
 
 

--- a/backend/src/api/routes/authentication.py
+++ b/backend/src/api/routes/authentication.py
@@ -9,7 +9,6 @@ from src.models.schema.account import (
     AccountInSignup,
     AccountWithToken,
 )
-from src.models.schema.profile import ProfileInSignup
 from src.repository.crud.account import AccountCRUDRepository
 from src.repository.crud.profile import ProfileCRUDRepository
 from src.security.authorizations.jwt import jwt_manager
@@ -30,7 +29,6 @@ router = fastapi.APIRouter(prefix="/auth", tags=["authentication"])
 )
 async def account_registration_endpoint(
     account_signup: AccountInSignup = fastapi.Body(..., embed=True),
-    profile_signup: ProfileInSignup = fastapi.Body(..., embed=True),
     account_crud: AccountCRUDRepository = fastapi.Depends(get_crud(repo_type=AccountCRUDRepository)),
     profile_crud: ProfileCRUDRepository = fastapi.Depends(get_crud(repo_type=ProfileCRUDRepository)),
 ) -> AccountInResponse:
@@ -40,7 +38,7 @@ async def account_registration_endpoint(
         raise await http_exc_400_credentials_bad_signup_request()
 
     new_account = await account_crud.create_account(account_signup=account_signup)
-    new_profile = await profile_crud.create_profile(profile_create=profile_signup, parent_account=new_account)
+    new_profile = await profile_crud.create_profile(parent_account=new_account)
     jwt_token = jwt_manager.generate_jwt(account=new_account)
     return AccountInResponse(
         authorized_account=AccountWithToken(

--- a/backend/src/api/routes/profile.py
+++ b/backend/src/api/routes/profile.py
@@ -5,7 +5,7 @@ import pydantic
 from src.api.dependency.crud import get_crud
 from src.api.dependency.header import get_auth_current_user
 from src.models.db.account import Account
-from src.models.schema.profile import ProfileInResponse, ProfileInSignup, ProfileInUpdate
+from src.models.schema.profile import ProfileInResponse, ProfileInUpdate
 from src.repository.crud.profile import ProfileCRUDRepository
 from src.utility.exceptions.custom import EntityDoesNotExist
 from src.utility.exceptions.database import DatabaseError

--- a/backend/src/models/db/profile.py
+++ b/backend/src/models/db/profile.py
@@ -15,9 +15,13 @@ class Profile(DBBaseTable):
     __tablename__ = "profile"
 
     id: SQLAlchemyMapped[int] = sqlalchemy_mapped_column(primary_key=True, autoincrement="auto")
-    first_name: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(sqlalchemy.String(length=64), nullable=True)
-    last_name: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(sqlalchemy.String(length=64), nullable=True)
-    photo: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(sqlalchemy.String(length=248), nullable=True)
+    first_name: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(
+        sqlalchemy.String(length=64), nullable=True, default=None
+    )
+    last_name: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(
+        sqlalchemy.String(length=64), nullable=True, default=None
+    )
+    photo: SQLAlchemyMapped[str] = sqlalchemy_mapped_column(sqlalchemy.String(length=248), nullable=True, default=None)
     win: SQLAlchemyMapped[int] = sqlalchemy_mapped_column(sqlalchemy.Integer(), nullable=False, default=0)
     loss: SQLAlchemyMapped[int] = sqlalchemy_mapped_column(sqlalchemy.Integer(), nullable=False, default=0)
     mmr: SQLAlchemyMapped[int] = sqlalchemy_mapped_column(sqlalchemy.Integer(), nullable=False, default=80)

--- a/backend/src/models/schema/account.py
+++ b/backend/src/models/schema/account.py
@@ -55,6 +55,11 @@ class AccountInResponse(BaseSchemaModel):
     authorized_account: AccountWithToken
 
 
+class AccountInSignupResponse(BaseSchemaModel):
+    authorized_account: AccountWithToken
+    is_profile_created: bool
+
+
 class AccountInSignoutResponse(BaseSchemaModel):
     username: str
     is_logged_out: bool

--- a/backend/src/models/schema/profile.py
+++ b/backend/src/models/schema/profile.py
@@ -9,19 +9,10 @@ from src.models.schema.base import BaseSchemaModel
 # ?             How is it being send to the client?
 
 
-class ProfileInSignup(BaseSchemaModel):
-    first_name: str
-    last_name: str
-    photo: str | None
-
-
 class ProfileInUpdate(BaseSchemaModel):
     first_name: str | None
     last_name: str | None
     photo: str | None
-    win: int | None
-    loss: int | None
-    mmr: int | None
 
 
 class ProfileInResponse(BaseSchemaModel):

--- a/backend/src/models/schema/profile.py
+++ b/backend/src/models/schema/profile.py
@@ -17,9 +17,9 @@ class ProfileInUpdate(BaseSchemaModel):
 
 class ProfileInResponse(BaseSchemaModel):
     id: int
-    first_name: str
-    last_name: str
-    photo: str
+    first_name: str | None
+    last_name: str | None
+    photo: str | None
     win: int
     loss: int
     mmr: int

--- a/backend/src/repository/crud/profile.py
+++ b/backend/src/repository/crud/profile.py
@@ -6,19 +6,16 @@ from sqlalchemy.sql import functions as sqlalchemy_functions
 
 from src.models.db.account import Account
 from src.models.db.profile import Profile
-from src.models.schema.profile import ProfileInSignup, ProfileInUpdate
+from src.models.schema.profile import ProfileInUpdate
 from src.repository.crud.base import BaseCRUDRepository
 from src.utility.exceptions.custom import EntityDoesNotExist
 from src.utility.exceptions.database import DatabaseError
 
 
 class ProfileCRUDRepository(BaseCRUDRepository):
-    async def create_profile(self, profile_create: ProfileInSignup, parent_account: Account) -> Profile:
+    async def create_profile(self, parent_account: Account) -> Profile:
         try:
             new_profile = Profile(
-                first_name=profile_create.first_name,
-                last_name=profile_create.last_name,
-                photo=profile_create.photo,
                 account=parent_account,
             )
             self.async_session.add(instance=new_profile)


### PR DESCRIPTION
- [x] Made ```first_name```, ```last_name``` and ```photo``` default to None when a profile is created without specific values for these parameters
- [x]  Allowed ```first_name```, ```last_name``` and ```photo``` to be None in the ```ProfilInResponse ``` schema
- [x] Added AccountInSignupResponse schema, which includes the bool is_profile_created